### PR TITLE
Disable disk cache for /api/dl.

### DIFF
--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -173,6 +173,7 @@ http {
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_max_temp_file_size 0;
         }
 
         location /api/ {


### PR DESCRIPTION
This will fix the downloads which are limited when the recipient has a slow network connection.