### PR TITLE
CSCFAIRMETA-201: Old Etsin redirect, add server block

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -12,7 +12,7 @@ redirect_ssl_certificate_key_name: redirect-nginx-selfsigned.key
 web_app_github_repo_branch: test
 search_app_github_repo_branch: test
 server_domain_name: etsin-finder.local
-redirect_server_domain_name: redirect.etsin-finder.local
+redirect_server_domain_name: redirect.{{server_domain_name}}
 
 nginx_es_credentials:
   - { username: etsin, password: test-etsin }
@@ -20,7 +20,6 @@ nginx_es_credentials:
 gunicorn_preload: false
 
 ssl_certificates_path: /etc/nginx/ssl_certs
-redirect_ssl_certificates_path: /etc/nginx/ssl_certs
 
 app_log_level: DEBUG
 app_debug_mode: True

--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -7,9 +7,12 @@ dataserver_1_internal_ip: 127.0.0.1
 deployment_environment_id: local_development
 ssl_certificate_name: nginx-selfsigned.crt
 ssl_key_name: nginx-selfsigned.key
+redirect_ssl_certificate_name: redirect-nginx-selfsigned.crt
+redirect_ssl_certificate_key_name: redirect-nginx-selfsigned.key
 web_app_github_repo_branch: test
 search_app_github_repo_branch: test
 server_domain_name: etsin-finder.local
+redirect_server_domain_name: redirect.etsin-finder.local
 
 nginx_es_credentials:
   - { username: etsin, password: test-etsin }
@@ -17,6 +20,7 @@ nginx_es_credentials:
 gunicorn_preload: false
 
 ssl_certificates_path: /etc/nginx/ssl_certs
+redirect_ssl_certificates_path: /etc/nginx/ssl_certs
 
 app_log_level: DEBUG
 app_debug_mode: True

--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Create self-signed redirect SSL cert and private key
   command: openssl req -x509 -nodes -subj "/C=FI/ST=Uusimaa/L=Espoo/O=CSC/CN={{ redirect_server_domain_name }}" -days 365 -newkey rsa:2048 -keyout {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }} -out {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }} creates={{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }}
-  when: deployment_environment_id in ['local_development', 'test', 'stable', 'demo']
+  when: deployment_environment_id not in ['production']
 
 - block:
 

--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -6,6 +6,10 @@
   command: openssl req -x509 -nodes -subj "/C=FI/ST=Uusimaa/L=Espoo/O=CSC/CN={{ server_domain_name }}" -days 365 -newkey rsa:2048 -keyout {{ ssl_certificates_path }}/{{ ssl_key_name }} -out {{ ssl_certificates_path }}/{{ ssl_certificate_name }} creates={{ ssl_certificates_path }}/{{ ssl_certificate_name }}
   when: deployment_environment_id in ['local_development', 'staging']
 
+- name: Create self-signed redirect SSL cert and private key
+  command: openssl req -x509 -nodes -subj "/C=FI/ST=Uusimaa/L=Espoo/O=CSC/CN={{ redirect_server_domain_name }}" -days 365 -newkey rsa:2048 -keyout {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }} -out {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }} creates={{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }}
+  when: deployment_environment_id in ['local_development', 'test', 'stable', 'demo']
+
 - block:
 
     - name: Install dos2unix

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -9,6 +9,9 @@
 - name: NGINX | Copy shared_headers.conf
   template: src=templates/shared_headers.conf dest=/etc/nginx/shared_headers.conf
 
+- name: NGINX | Copy shared_ssl_configurations.conf
+  template: src=templates/shared_ssl_configurations.conf dest=/etc/nginx/shared_ssl_configurations.conf
+
 - name: NGINX | Copy api_response_headers.conf
   template: src=templates/api_response_headers.conf dest=/etc/nginx/api_response_headers.conf
 

--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -103,16 +103,7 @@ http {
         listen 443 ssl http2 default_server;
         listen [::]:443 ssl http2 default_server;
         server_name {{ server_domain_name }};
-        ssl_protocols TLSv1.1 TLSv1.2;
-        ssl_prefer_server_ciphers on;
-        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
-        ssl_ecdh_curve secp384r1;
-        ssl_session_cache shared:SSL:10m;
-        ssl_session_tickets off;
-        ssl_stapling on;
-        ssl_stapling_verify on;
-        resolver 8.8.8.8 8.8.4.4 valid=300s;
-        resolver_timeout 5s;
+        include shared_ssl_configurations.conf;
 
         ssl_certificate {{ ssl_certificates_path }}/{{ ssl_certificate_name }};
         ssl_certificate_key {{ ssl_certificates_path }}/{{ ssl_key_name }};
@@ -194,13 +185,23 @@ http {
         }
     }
 
-    # Redirect from etsin.avointiede.fi (old Etsin) to etsin.fairdata.fi (new Etsin)
+    # Redirect from etsin.avointiede.fi (old Etsin) to etsin.fairdata.fi (new Etsin), port 443
     server {
         server_name {{ redirect_server_domain_name }};
+        include shared_ssl_configurations.conf;
+
         listen 443 ssl;
         ssl_certificate {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }};
         ssl_certificate_key {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }};
 
         return 301 https://{{ server_domain_name }}$request_uri;
+    }
+
+    # Redirect from etsin.avointiede.fi (old Etsin) to etsin.fairdata.fi (new Etsin), port 80
+    server {
+        listen 80 {{ redirect_server_domain_name }};
+        server_name {{ redirect_server_domain_name }};
+        return 301 https://{{ server_domain_name }}$request_uri;
+        access_log on;
     }
 }

--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -193,4 +193,14 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
+
+    # Redirect from etsin.avointiede.fi (old Etsin) to etsin.fairdata.fi (new Etsin)
+    server {
+        server_name etsin.avointiede.fi;
+        listen 443 ssl;
+        ssl_certificate {{ ssl_certificates_path }}/etsin.avointiede.fi.crt;
+        ssl_certificate_key {{ ssl_certificates_path }}/etsin.avointiede.fi.key;
+
+        return 301 https://etsin.fairdata.fi$request_uri;
+    }
 }

--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -190,18 +190,11 @@ http {
         server_name {{ redirect_server_domain_name }};
         include shared_ssl_configurations.conf;
 
+        listen 80;
         listen 443 ssl;
         ssl_certificate {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }};
         ssl_certificate_key {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }};
 
         return 301 https://{{ server_domain_name }}$request_uri;
-    }
-
-    # Redirect from etsin.avointiede.fi (old Etsin) to etsin.fairdata.fi (new Etsin), port 80
-    server {
-        listen 80 {{ redirect_server_domain_name }};
-        server_name {{ redirect_server_domain_name }};
-        return 301 https://{{ server_domain_name }}$request_uri;
-        access_log on;
     }
 }

--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -196,11 +196,11 @@ http {
 
     # Redirect from etsin.avointiede.fi (old Etsin) to etsin.fairdata.fi (new Etsin)
     server {
-        server_name etsin.avointiede.fi;
+        server_name {{ redirect_server_domain_name }};
         listen 443 ssl;
-        ssl_certificate {{ ssl_certificates_path }}/etsin.avointiede.fi.crt;
-        ssl_certificate_key {{ ssl_certificates_path }}/etsin.avointiede.fi.key;
+        ssl_certificate {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }};
+        ssl_certificate_key {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }};
 
-        return 301 https://etsin.fairdata.fi$request_uri;
+        return 301 https://{{ server_domain_name }}$request_uri;
     }
 }

--- a/ansible/roles/nginx/templates/shared_ssl_configurations.conf
+++ b/ansible/roles/nginx/templates/shared_ssl_configurations.conf
@@ -1,0 +1,10 @@
+ssl_protocols TLSv1.1 TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+ssl_ecdh_curve secp384r1;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;
+resolver 8.8.8.8 8.8.4.4 valid=300s;
+resolver_timeout 5s;


### PR DESCRIPTION
- etsin.avointiede.fi must be redirected to etsin.fairdata.fi
- Added server bloc for etsin.avointiede.fi. Secret files have been added (.crt / .key) too.