### PR TITLE
CSCFAIRMETA-325: ElasticSearch role does not work with latest Ansible.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ if [ ! -f /vagrant_bootstrap_done.info ]; then
   sudo yum -y install epel-release python-devel libffi-devel openssl-devel git
   sudo yum -y install python-pip
   sudo pip install pip --upgrade
-  sudo pip install ansible
+  sudo pip install "ansible>=2.4,<2.9"
   cd /etsin/ansible
   source install_requirements.sh
   ansible-playbook site_provision.yml


### PR DESCRIPTION
We need to specify the required Ansible in the Vagrantfile.