### PR TITLE
CSCFAIRMETA-367: ssl generation fails with etsin-ops for local dev

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -48,3 +48,54 @@ elasticsearch:
     - 127.0.0.1
   port: 9200
   use_ssl: False
+
+metax_rabbitmq_hosts:
+  - 127.0.0.1
+
+metax_rabbitmq:
+  hosts: "{{ metax_rabbitmq_hosts }}"
+  vhost: metax
+  exchange: datasets
+  user: metax-user
+  password: changeme
+  port: 5672
+
+metax_api:
+  host: metax.csc.local
+  user: qvain
+  password: test-qvain
+  verify_ssl: False
+
+metax_qvain_api:
+  host: metax.csc.local
+  user: qvain
+  password: test-qvain
+  verify_ssl: False
+
+download_api:
+  host: download.csc.local
+  port: 4433
+  user: etsin
+  password: changeme
+
+memcached:
+  host: localhost
+  port: 11211
+
+saml:
+  debug: true
+  strict: true
+  sp_entity_id: https://etsin.csc.local/saml_metadata/
+  sp_acs_url: https://etsin.csc.local/acs/
+  sp_sls_url: https://etsin.csc.local/sls/
+  sp_x509_cert: changeme
+  sp_private_key: changeme
+  idp_entity_id: https://auth.csc.local/idp/shibboleth
+  idp_sso_url: https://auth.csc.local/idp/profile/SAML2/Redirect/SSO
+  idp_x509_cert: changeme
+  idp_sls_url: http://auth.csc.local/idp/profile/Logout
+
+fd_rems:
+  enabled: false
+  host: localhost
+  api_key: changeme

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -25,13 +25,13 @@ MAIL_DEFAULT_SENDER: {{ app_mail_default_sender }}
 
 # Variables related to elasticsearch
 ELASTICSEARCH:
-  HOSTS: {{ elasticsearch.hosts | to_nice_json }}
+  HOSTS: {{ elasticsearch.hosts | default([]) | to_nice_json }}
   PORT: {{ elasticsearch.port }}
   USE_SSL: {{ elasticsearch.use_ssl }}
 
 # Variables related to Metax rabbitmq
 METAX_RABBITMQ:
-  HOSTS: {{ metax_rabbitmq.hosts | to_nice_json }}
+  HOSTS: {{ metax_rabbitmq.hosts | default([]) | to_nice_json }}
   PORT: {{ metax_rabbitmq.port }}
   VHOST: {{ metax_rabbitmq.vhost }}
   EXCHANGE: {{ metax_rabbitmq.exchange }}
@@ -67,5 +67,5 @@ MEMCACHED:
 # Variables related to Fairdata Rems API
 FD_REMS:
   ENABLED: {{ fd_rems.enabled | default(false) }}
-  HOST: {{ fd_rems.host | default(omit) }}
-  API_KEY: {{ fd_rems.api_key | default(omit) }}
+  HOST: {{ fd_rems.host | default('127.0.0.1') }}
+  API_KEY: {{ fd_rems.api_key | default('changeme') }}

--- a/ansible/roles/certificates/tasks/create-cert.yml
+++ b/ansible/roles/certificates/tasks/create-cert.yml
@@ -1,0 +1,62 @@
+#########################################################
+# This task file contains command to create new ssl cert
+# for development and testing use.
+#
+# USAGE:
+#--------------------------------------------------------
+# - name: "Generate SSL certs"
+#   block:
+#     - include_tasks: openssl-11.yml
+#     - set_fact:
+#         self_signed_cert:
+#           description: self-signed SSL cert and private key
+#           enabled: true
+#           organisation: CSC
+#           location: Espoo
+#           state: Uusimaa
+#           country: FI
+#           common_name: "{{ server_domain_name }}"
+#           dns: "{{ server_domain_name }}"
+#           keyout: "{{ ssl_certificates_path }}/{{ ssl_key_name }}"
+#           out: "{{ ssl_certificates_path }}/{{ ssl_certificate_name }}"
+#           days: 365
+#     - set_fact:
+#         certs:
+#           - "{{ self_signed_cert }}"
+#     - name: Generate self-signed certs
+#       include_tasks: create-cert.yml
+#       with_items: "{{ certs }}"
+#       loop_control:
+#         loop_var: cert
+#     - set_fact:
+#         self_signed_cert:
+#         certs:
+#--------------------------------------------------------
+# Author(s):
+#      Juhapekka Piiroinen <juhapekka.piiroinen@csc.fi>
+#
+# License: MIT
+#
+# (C) 2020 Copyright CSC - IT Center for Science Ltd.
+# All Rights Reserved.
+#########################################################
+---
+- fail:
+    msg: "cert is not defined"
+  when: cert is undefined
+- fail:
+    msg: "openssl is not defined, you need to include openssl-11.yml."
+  when: openssl is undefined
+
+- debug:
+    var: cert
+
+- name: "{{ cert.description }}"
+  command:
+    cmd: openssl req -x509 -nodes -subj "/C={{ cert.country }}/ST={{ cert.state }}/L={{ cert.location }}/O={{ cert.organisation }}/CN={{ cert.common_name }}" -addext "subjectAltName = DNS:{{ cert.dns }}" -addext "extendedKeyUsage = serverAuth" -days {{ cert.days }} -newkey rsa:2048 -keyout {{ cert.keyout }} -out {{ cert.out }}
+    creates: "{{ cert.out }}"
+  environment:
+    LD_LIBRARY_PATH: "{{ openssl.lib_path }}"
+    OPENSSL_CONF: "{{ openssl.build_path }}/openssl.cnf"
+    PATH: "{{ openssl.bin_path }}:{{ ansible_env.PATH }}"
+  when: cert.enabled

--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -1,17 +1,55 @@
+---
 - name: Create directory for SSL certificates
   file: path={{ ssl_certificates_path }} state=directory
   when: deployment_environment_id in ['local_development', 'test', 'stable', 'staging', 'demo']
 
-- name: Create self-signed SSL cert and private key
-  command: openssl req -x509 -nodes -subj "/C=FI/ST=Uusimaa/L=Espoo/O=CSC/CN={{ server_domain_name }}" -addext "subjectAltName = DNS:{{ server_domain_name }}" -addext "extendedKeyUsage = serverAuth" -days 365 -newkey rsa:2048 -keyout {{ ssl_certificates_path }}/{{ ssl_key_name }} -out {{ ssl_certificates_path }}/{{ ssl_certificate_name }} creates={{ ssl_certificates_path }}/{{ ssl_certificate_name }}
-  when: deployment_environment_id in ['local_development', 'staging']
-
-- name: Create self-signed redirect SSL cert and private key
-  command: openssl req -x509 -nodes -subj "/C=FI/ST=Uusimaa/L=Espoo/O=CSC/CN={{ redirect_server_domain_name }}" -addext "subjectAltName = DNS:{{ redirect_server_domain_name }}" -addext "extendedKeyUsage = serverAuth" -days 365 -newkey rsa:2048 -keyout {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }} -out {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }} creates={{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }}
+- name: Create self-signed SSL certs for non-production
+  block:
+    - name: Fetch, build and install openssl 1.1
+      block:
+        - include_tasks: openssl-11.yml
+        - set_fact:
+            self_signed_cert:
+              description: self-signed SSL cert and private key
+              enabled: deployment_environment_id in ['local_development', 'staging']
+              organisation: CSC
+              location: Espoo
+              state: Uusimaa
+              country: FI
+              common_name: "{{ server_domain_name }}"
+              dns: "{{ server_domain_name }}"
+              keyout: "{{ ssl_certificates_path }}/{{ ssl_key_name }}"
+              out: "{{ ssl_certificates_path }}/{{ ssl_certificate_name }}"
+              days: 365
+            self_signed_redirect_cert:
+              description: self-signed redirect SSL cert and private key
+              enabled: true
+              organisation: CSC
+              location: Espoo
+              state: Uusimaa
+              country: FI
+              common_name: "{{ redirect_server_domain_name }}"
+              dns: "{{ redirect_server_domain_name }}"
+              keyout: "{{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }}"
+              out: "{{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }}"
+              days: 365
+        - set_fact:
+            certs:
+              - "{{ self_signed_cert }}"
+              - "{{ self_signed_redirect_cert }}"
+    - name: Generate self-signed certs
+      include_tasks: create-cert.yml
+      with_items: "{{ certs }}"
+      loop_control:
+        loop_var: cert
+    - set_fact:
+        openssl:
+        self_signed_cert:
+        self_signed_redirect_cert:
+        certs:
   when: deployment_environment_id not in ['production']
 
 - block:
-
     - name: Install dos2unix
       yum: name=dos2unix state=latest
 

--- a/ansible/roles/certificates/tasks/openssl-11.yml
+++ b/ansible/roles/certificates/tasks/openssl-11.yml
@@ -1,0 +1,99 @@
+#########################################################
+# This task file contains command to install openssl 1.1
+#
+# USAGE:
+#--------------------------------------------------------
+# - include_tasks: openssl-11.yml
+#--------------------------------------------------------
+# Author(s):
+#      Juhapekka Piiroinen <juhapekka.piiroinen@csc.fi>
+#
+# License: MIT
+#
+# (C) 2020 Copyright CSC - IT Center for Science Ltd.
+# All Rights Reserved.
+#########################################################
+---
+- fail:
+    msg: "openssl variable is already set, this would override it."
+  when: openssl is defined
+
+- set_fact:
+    openssl:
+      root_path: /opt/openssl-1.1
+      source_path: "/opt/openssl-1.1/openssl-OpenSSL_1_1_1d"
+      build_path: "/opt/openssl-1.1/build"
+      bin_path: "/opt/openssl-1.1/build/bin"
+      lib_path: "/opt/openssl-1.1/build/lib"
+
+- name: "Check if openssl is already installed"
+  block:
+    - name: "Does the built binary exist"
+      stat:
+        path: "{{ openssl.bin_path }}/openssl"
+      register: openssl_binary
+
+    - name: "Check openssl version"
+      shell: openssl version
+      ignore_errors: yes
+      register: openssl_version
+
+    - set_fact:
+        openssl_version: "{{ openssl_version.stdout | regex_search('([0-9].[0-9].[0-9][a-z])') }}"
+
+- name: "Setup openssl 1.1"
+  block:
+    - name: "Get source"
+      block:
+        - name: "Create paths for openssl"
+          block:
+            - file:
+                path: "{{ item }}"
+                state: directory
+                mode: '0755'
+              with_items:
+                - "{{ openssl.root_path }}"
+                - "{{ openssl.source_path }}"
+                - "{{ openssl.bin_path }}"
+                - "{{ openssl.lib_path }}"
+
+        - name: "Download openssl source"
+          get_url:
+            url: https://github.com/openssl/openssl/archive/OpenSSL_1_1_1d.tar.gz
+            dest: "{{ openssl.root_path }}/OpenSSL_1_1_1d.tar.gz"
+            checksum: sha1:df0ee4811c87c209ebadb4e6b203d1e560d00f9a
+
+        - name: "Extract source"
+          unarchive:
+            src: "{{ openssl.root_path }}/OpenSSL_1_1_1d.tar.gz"
+            dest: "{{ openssl.root_path }}"
+            remote_src: yes
+
+    - name: "Build openssl 1.1"
+      block:
+        - name: "Run configure"
+          shell:
+            cmd: ./config shared --openssldir={{ openssl.build_path }} --prefix={{ openssl.build_path }}
+            chdir: "{{ openssl.source_path }}"
+
+        - name: "Build"
+          shell:
+            cmd: make
+            chdir: "{{ openssl.source_path }}"
+
+        - name: "Install to build path"
+          shell:
+            cmd: make install
+            chdir: "{{ openssl.source_path }}"
+
+    - name: "Remove source and temporary files"
+      block:
+        - file:
+            path: "{{ item }}"
+            state: absent
+          with_items:
+            - "{{ openssl.source_path }}"
+            - "{{ openssl.root_path }}/OpenSSL_1_1_1d.tar.gz"
+  when:
+    - not openssl_binary.stat.exists
+    - openssl_version is version('1.1', '<')


### PR DESCRIPTION
There is no OpenSSL 1.1 series for Centos 7. So we will need to have one for ansible use.