### PR TITLE
CSCFAIRMETA-382: Redirect changes

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -20,6 +20,7 @@ nginx_es_credentials:
 gunicorn_preload: false
 
 ssl_certificates_path: /etc/nginx/ssl_certs
+redirect_ssl_certificates_path: /etc/nginx/redirect_ssl_certs
 
 app_log_level: DEBUG
 app_debug_mode: True

--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -3,6 +3,10 @@
   file: path={{ ssl_certificates_path }} state=directory
   when: deployment_environment_id in ['local_development', 'test', 'stable', 'staging', 'demo']
 
+- name: Create separate directory for redirect SSL certificates
+  file: path={{ redirect_ssl_certificates_path }} state=directory
+  when: deployment_environment_id in ['local_development', 'test', 'stable', 'staging', 'demo']
+
 - name: Create self-signed SSL certs for non-production
   block:
     - name: Fetch, build and install openssl 1.1
@@ -30,8 +34,8 @@
               country: FI
               common_name: "{{ redirect_server_domain_name }}"
               dns: "{{ redirect_server_domain_name }}"
-              keyout: "{{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }}"
-              out: "{{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }}"
+              keyout: "{{ redirect_ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }}"
+              out: "{{ redirect_ssl_certificates_path }}/{{ redirect_ssl_certificate_name }}"
               days: 365
         - set_fact:
             certs:

--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -192,8 +192,8 @@ http {
 
         listen 80;
         listen 443 ssl;
-        ssl_certificate {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_name }};
-        ssl_certificate_key {{ ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }};
+        ssl_certificate {{ redirect_ssl_certificates_path }}/{{ redirect_ssl_certificate_name }};
+        ssl_certificate_key {{ redirect_ssl_certificates_path }}/{{ redirect_ssl_certificate_key_name }};
 
         return 301 https://{{ server_domain_name }}$request_uri;
     }


### PR DESCRIPTION
- Add a separate folder for redirect certificates, redirect_ssl_certificates_path
- The added folder replaces the ssl_certificates_path, thus separating the actual certificates from the redirect ones