### PR TITLE
CSCFAIRADM-244: Update test and stable certificates

### DIFF
--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Create directory for SSL certificates
   file: path={{ ssl_certificates_path }} state=directory
-  when: deployment_environment_id in ['local_development', 'test', 'stable', 'staging', 'demo']
+  when: deployment_environment_id in ['local_development', 'staging', 'demo']
 
 - name: Create separate directory for redirect SSL certificates
   file: path={{ redirect_ssl_certificates_path }} state=directory
-  when: deployment_environment_id in ['local_development', 'test', 'stable', 'staging', 'demo']
+  when: deployment_environment_id in ['local_development', 'staging', 'demo']
 
-- name: Create self-signed SSL certs for non-production
+- name: Create self-signed SSL certs for local_development, staging, and demo
   block:
     - name: Fetch, build and install openssl 1.1
       block:
@@ -51,7 +51,7 @@
         self_signed_cert:
         self_signed_redirect_cert:
         certs:
-  when: deployment_environment_id not in ['production']
+  when: deployment_environment_id not in ['production', 'test', 'stable']
 
 - block:
     - name: Install dos2unix
@@ -72,4 +72,4 @@
     - name: Fix concatenated file carriage returns
       command: dos2unix {{ ssl_certificates_path }}/{{ ssl_certificate_name }}
 
-  when: deployment_environment_id in ['test', 'stable', 'demo']
+  when: deployment_environment_id in ['demo']

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -25,6 +25,14 @@
 
 - name: NGINX | Generate Diffie-Hellman PFS (Perfect Forward Secrecy) group
   command: openssl dhparam -out {{ ssl_certificates_path }}/{{ nginx_dh_param_name }} 2048 creates={{ ssl_certificates_path }}/{{ nginx_dh_param_name }}
+  when: deployment_environment_id not in ['test', 'stable']
+  
+- name: NGINX | For test & stable, remotely copy & rename ssl-dhparams.pem, retrieved using LetsEncrypt, to the correct location
+  copy:
+    src: /etc/letsencrypt/ssl-dhparams.pem
+    dest: /{{ ssl_certificates_path }}/nginx_dhparam.pem
+    remote_src: yes
+  when: deployment_environment_id in ['test', 'stable']
 
 - name: NGINX | Install passlib
   pip: name=passlib state=latest executable=pip3

--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -96,11 +96,6 @@ http {
 {% endif %}
     }
 
-    upstream matomo {
-        keepalive 15;
-        server {{ matomo.host | default('matomo.csc.local') }}:{{ matomo.port | default(80) }} weight=3;
-    }
-
     server {
 
         # https configuration
@@ -166,29 +161,6 @@ http {
             add_header Cache-Control "no-store" always;
             add_header Content-Security-Policy "default-src 'self'";
             proxy_pass {{ nginx_gunicorn_proxy_pass }};
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_max_temp_file_size 0;
-        }
-
-        location = /matomo.php {
-            include shared_headers.conf;
-            add_header Cache-Control "no-store" always;
-            add_header Content-Security-Policy "default-src 'self'";
-            proxy_pass http://{{ matomo.host }}/matomo.php;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_max_temp_file_size 0;
-        }
-
-
-        location = /matomo.js {
-            include shared_headers.conf;
-            add_header Cache-Control "no-store" always;
-            add_header Content-Security-Policy "default-src 'self'";
-            proxy_pass http://{{ matomo.host }}/matomo.js;
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
**e104641 Remove self-signed certificates from test and stable**
- This process is done through a query to LetsEncrypt now
- Excluding test and stable from the process
- In the future, this new process could potentially be automated

**a891357 dhparam is retrieved from LetsEncrypt so should be copied to correct place**
- In test and stable, the generation of a PFS group is no longer needed since nginx_dh_param_name is retrieved from LetsEncrypt
- Simple copy of relevant variable (nginx_dh_param_name) to correct folder and name for test and stable

**4cda089 Remove Matomo references that have caused problems**
- These variables are not actively used and can be removed