### PR TITLE
CSCFAIRADM-247: Add Google HTML file to ansible

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -6,6 +6,9 @@
 - name: NGINX | Replace NGINX conf file
   template: src=templates/etsin_nginx.conf dest=/etc/nginx/nginx.conf
 
+- name: NGINX | Add Google search console ownership verification file
+  template: src=files/google18c2b346e42a601e.html dest={{ web_app_frontend_path }}/build/google18c2b346e42a601e.html
+
 - name: NGINX | Copy shared_headers.conf
   template: src=templates/shared_headers.conf dest=/etc/nginx/shared_headers.conf
 


### PR DESCRIPTION
Add Google HTML file to ansible, which is copied at the same time as the nginx config