### PR TITLE
CSCFAIRMETA-706: Allow Etsin have a separate domain for Qvain

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -12,6 +12,7 @@ redirect_ssl_certificate_key_name: redirect-nginx-selfsigned.key
 web_app_github_repo_branch: test
 search_app_github_repo_branch: test
 server_domain_name: etsin-finder.local
+server_qvain_domain_name: qvain.local
 redirect_server_domain_name: redirect.{{server_domain_name}}
 
 nginx_es_credentials:

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -9,7 +9,7 @@ SEARCH_APP_LOG_PATH: {{ search_app_log_base_path }}/{{ search_app_project_name }
 # Variables related to etsin_finder app config
 DEBUG: {{ app_debug_mode }}
 SECRET_KEY: {{ app_secret_key }}
-SESSION_COOKIE_SAMESITE: Lax
+SESSION_COOKIE_SAMESITE: None
 SESSION_COOKIE_SECURE: True
 SESSION_COOKIE_HTTPONLY: True
 PERMANENT_SESSION_LIFETIME: 1800

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -10,6 +10,9 @@
   template: src=files/google18c2b346e42a601e.html dest={{ web_app_frontend_path }}/build/google18c2b346e42a601e.html
   when: deployment_environment_id not in ['local_development']
 
+- name: NGINX | Copy server_common.conf
+  template: src=templates/server_common.conf dest=/etc/nginx/server_common.conf
+
 - name: NGINX | Copy shared_headers.conf
   template: src=templates/shared_headers.conf dest=/etc/nginx/shared_headers.conf
 

--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -51,6 +51,14 @@ http {
     gzip_min_length 256;
     gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
 
+    # Match allowed origins for cross-origin API requests
+    map $http_origin $allow_origin {
+        https://{{ server_domain_name }} $http_origin;
+{% if server_qvain_domain_name is not undefined %}
+        https://{{ server_qvain_domain_name }} $http_origin;
+{% endif %}
+    }
+
     # server {
     #     # handle unknown domain names or Host header values
     #     listen 80 default_server;
@@ -76,7 +84,6 @@ http {
     # }
 
     server {
-
         # port 80 only redirects to https
 
         listen 80 default_server;
@@ -96,70 +103,67 @@ http {
 {% endif %}
     }
 
+{% if server_qvain_domain_name is not undefined %}
     server {
+        # redirect Qvain port 80 to https
+        listen 80;
+        server_name {{ server_qvain_domain_name }};
+        return 301 https://{{ server_qvain_domain_name }}$request_uri;
+        access_log on;
+    }
 
-        # https configuration
+    server {
+        # Qvain https configuration
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name {{ server_qvain_domain_name }};
 
-        listen 443 ssl http2 default_server;
-        listen [::]:443 ssl http2 default_server;
-        server_name {{ server_domain_name }};
         include shared_ssl_configurations.conf;
+        include server_common.conf;
 
         ssl_certificate {{ ssl_certificates_path }}/{{ ssl_certificate_name }};
         ssl_certificate_key {{ ssl_certificates_path }}/{{ ssl_key_name }};
         ssl_dhparam {{ ssl_certificates_path }}/{{ nginx_dh_param_name }};
 
-{% if deployment_environment_id not in ['production'] %}
-        location =/robots.txt {
-            include shared_headers.conf;
-            include static_file_headers.conf;
-            alias /etc/nginx/robots.txt;
-        }
-{% endif %}
-
-        location /es/metax/dataset/_search {
-            include shared_headers.conf;
-            include elastic_headers.conf;
-            proxy_pass http://elasticsearch/metax/dataset/_search;
-            limit_except GET HEAD POST {
-                auth_basic 'Credentials required';
-                auth_basic_user_file /etc/nginx/es_auth;
-            }
+        # Etsin URL should be used for for /api/
+        location /api/ {
+            return 404;
         }
 
-        location /es/ {
+        location / {
             include shared_headers.conf;
-            include elastic_headers.conf;
-            proxy_pass http://elasticsearch/;
-            limit_except GET HEAD {
-                auth_basic 'Credentials required';
-                auth_basic_user_file /etc/nginx/es_auth;
-            }
-        }
-
-        location ~ ^/(sso|slo|saml_metadata|acs|sls) {
-            include shared_headers.conf;
-            add_header Cache-Control "no-store" always;
-
-            rewrite ^/(.*)$ /$1 break;
-            proxy_pass {{ nginx_gunicorn_proxy_pass }};
-
+            proxy_pass http://unix:/usr/local/etsin/gunicorn/socket;
+            add_header Set-Cookie "etsin_app=qvain; SameSite=Lax; Secure";
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
+    }
+{% endif %}
 
-        location /build/ {
-            include shared_headers.conf;
-            include static_file_headers.conf;
-            alias {{ nginx_static_root }};
-        }
+    server {
+        # Etsin https configuration
+
+        listen 443 ssl http2 default_server;
+        listen [::]:443 ssl http2 default_server;
+        server_name {{ server_domain_name }};
+
+        include shared_ssl_configurations.conf;
+        include server_common.conf;
+
+        ssl_certificate {{ ssl_certificates_path }}/{{ ssl_certificate_name }};
+        ssl_certificate_key {{ ssl_certificates_path }}/{{ ssl_key_name }};
+        ssl_dhparam {{ ssl_certificates_path }}/{{ nginx_dh_param_name }};
 
         location /api/dl {
             # separate block for dl api to not include content-disposition header
             include shared_headers.conf;
             add_header Cache-Control "no-store" always;
             add_header Content-Security-Policy "default-src 'self'";
+            add_header Access-Control-Allow-Credentials true;
+            add_header Access-Control-Allow-Origin $allow_origin always;
+            add_header Access-Control-Allow-Headers 'charset, content-type';
+
             proxy_pass {{ nginx_gunicorn_proxy_pass }};
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -171,6 +175,10 @@ http {
             include shared_headers.conf;
             include api_response_headers.conf;
             proxy_pass {{ nginx_gunicorn_proxy_pass }};
+            add_header Access-Control-Allow-Credentials true;
+            add_header Access-Control-Allow-Origin $allow_origin always;
+            add_header Access-Control-Allow-Headers 'charset, content-type';
+
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/ansible/roles/nginx/templates/server_common.conf
+++ b/ansible/roles/nginx/templates/server_common.conf
@@ -1,0 +1,62 @@
+{% if deployment_environment_id in ['local_development'] %}
+# redirect websocket to webpack development server
+location /sockjs-node/ {
+    include shared_headers.conf;
+    proxy_pass http://localhost:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+{% endif %}
+
+{% if deployment_environment_id not in ['production'] %}
+location =/robots.txt {
+    include shared_headers.conf;
+    include static_file_headers.conf;
+    alias /etc/nginx/robots.txt;
+}
+{% endif %}
+
+location /static/ {
+    include shared_headers.conf;
+    expires 1M;
+    add_header Cache-Control "public";
+}
+
+location /es/metax/dataset/_search {
+    include shared_headers.conf;
+    include elastic_headers.conf;
+    proxy_pass http://elasticsearch/metax/dataset/_search;
+    limit_except GET HEAD POST {
+        auth_basic 'Credentials required';
+        auth_basic_user_file /etc/nginx/es_auth;
+    }
+}
+
+location /es/ {
+    include shared_headers.conf;
+    include elastic_headers.conf;
+    proxy_pass http://elasticsearch/;
+    limit_except GET HEAD {
+        auth_basic 'Credentials required';
+        auth_basic_user_file /etc/nginx/es_auth;
+    }
+}
+
+location ~ ^/(sso|slo|saml_metadata|acs|sls) {
+    include shared_headers.conf;
+    add_header Cache-Control "no-store" always;
+
+    rewrite ^/(.*)$ /$1 break;
+    proxy_pass {{ nginx_gunicorn_proxy_pass }};
+
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+location /build/ {
+    include shared_headers.conf;
+    include static_file_headers.conf;
+    alias {{ nginx_static_root }};
+}


### PR DESCRIPTION
* Add nginx support for serving Qvain from alternate domain
* Add inventory variable server_qvain_domain_name
* Backend API requests for both Etsin and Qvain domains use Etsin domain in order to share the login session
* Add support for cross-origin requests to backend API
* Set SameSite=None for session cookie to allow cross-origin access
* For the Qvain domain, add etsin_app=qvain cookie which will help the frontend identify it should serve Qvain