### PR TITLE
CSCFAIRMETA-706: Use separate session for Etsin and Qvain

### DIFF
--- a/ansible/roles/nginx/templates/etsin_nginx.conf
+++ b/ansible/roles/nginx/templates/etsin_nginx.conf
@@ -51,14 +51,6 @@ http {
     gzip_min_length 256;
     gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
 
-    # Match allowed origins for cross-origin API requests
-    map $http_origin $allow_origin {
-        https://{{ server_domain_name }} $http_origin;
-{% if server_qvain_domain_name is not undefined %}
-        https://{{ server_qvain_domain_name }} $http_origin;
-{% endif %}
-    }
-
     # server {
     #     # handle unknown domain names or Host header values
     #     listen 80 default_server;
@@ -125,15 +117,11 @@ http {
         ssl_certificate_key {{ ssl_certificates_path }}/{{ ssl_key_name }};
         ssl_dhparam {{ ssl_certificates_path }}/{{ nginx_dh_param_name }};
 
-        # Etsin URL should be used for for /api/
-        location /api/ {
-            return 404;
-        }
-
         location / {
             include shared_headers.conf;
-            proxy_pass http://unix:/usr/local/etsin/gunicorn/socket;
-            add_header Set-Cookie "etsin_app=qvain; SameSite=Lax; Secure";
+            proxy_pass {{ nginx_gunicorn_proxy_pass }};
+            add_header Set-Cookie "etsin_app=qvain; path=/; SameSite=Lax; Secure";
+            proxy_set_header X-Etsin-App "qvain";
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -155,38 +143,11 @@ http {
         ssl_certificate_key {{ ssl_certificates_path }}/{{ ssl_key_name }};
         ssl_dhparam {{ ssl_certificates_path }}/{{ nginx_dh_param_name }};
 
-        location /api/dl {
-            # separate block for dl api to not include content-disposition header
-            include shared_headers.conf;
-            add_header Cache-Control "no-store" always;
-            add_header Content-Security-Policy "default-src 'self'";
-            add_header Access-Control-Allow-Credentials true;
-            add_header Access-Control-Allow-Origin $allow_origin always;
-            add_header Access-Control-Allow-Headers 'charset, content-type';
-
-            proxy_pass {{ nginx_gunicorn_proxy_pass }};
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_max_temp_file_size 0;
-        }
-
-        location /api/ {
-            include shared_headers.conf;
-            include api_response_headers.conf;
-            proxy_pass {{ nginx_gunicorn_proxy_pass }};
-            add_header Access-Control-Allow-Credentials true;
-            add_header Access-Control-Allow-Origin $allow_origin always;
-            add_header Access-Control-Allow-Headers 'charset, content-type';
-
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
         location / {
             include shared_headers.conf;
             proxy_pass {{ nginx_gunicorn_proxy_pass }};
+            add_header Set-Cookie "etsin_app=etsin; path=/; SameSite=Lax; Secure";
+            proxy_set_header X-Etsin-App "etsin";
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/ansible/roles/nginx/templates/server_common.conf
+++ b/ansible/roles/nginx/templates/server_common.conf
@@ -60,3 +60,25 @@ location /build/ {
     include static_file_headers.conf;
     alias {{ nginx_static_root }};
 }
+
+location /api/dl {
+    # separate block for dl api to not include content-disposition header
+    include shared_headers.conf;
+    add_header Cache-Control "no-store" always;
+    add_header Content-Security-Policy "default-src 'self'";
+
+    proxy_pass {{ nginx_gunicorn_proxy_pass }};
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_max_temp_file_size 0;
+}
+
+location /api/ {
+    include shared_headers.conf;
+    include api_response_headers.conf;
+    proxy_pass {{ nginx_gunicorn_proxy_pass }};
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}


### PR DESCRIPTION
* Revert parts of previous change where Etsin and Qvain sites shared login session
* Remove CORS configuration that is no longer needed
* Add X-Etsin-App header to help the backend customize rendering of index.html based on the desired app
* Set etsin_app cookie also for Etsin
* Fix hardcoded URL being used instead of nginx_gunicorn_proxy_pass variable