### PR TITLE
CSCFAIRADM-389: Remove NODE_ENV = test specification

### DIFF
--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -41,20 +41,12 @@
           chdir: "{{ web_app_frontend_path }}"
 
       - name: Run frontend build for pouta test environments
-        shell: npm run build -- --define process.env.NODE_ENV="'test'"
-        become_user: "{{ app_user }}"
-        args:
-          executable: /bin/bash
-          chdir: "{{ web_app_frontend_path }}"
-        when: deployment_environment_id in ['test', 'stable', 'demo']
-
-      - name: Run frontend build for production-like pouta environments
         shell: npm run build
         become_user: "{{ app_user }}"
         args:
           executable: /bin/bash
           chdir: "{{ web_app_frontend_path }}"
-        when: deployment_environment_id == 'staging'
+        when: deployment_environment_id in ['test', 'stable', 'demo', 'staging']
 
       - name: Run frontend build for production environment
         shell: npm run build -- --define process.env.MATOMO="'true'"


### PR DESCRIPTION
- This PR aims to fix issues in Travis with the Node/npm version

See: https://travis-ci.org/github/CSCfi/etsin-finder/jobs/731221691
- Travis already runs the tests with specification `--config webpack.prod.js --define process.env.NODE_ENV='production'`
- ... so there is no need to additionally specify `--define process.env.NODE_ENV='test'`