### PR TITLE
Revert "CSCFAIRADM-389: Remove NODE_ENV = test specification"

### DIFF
--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -41,12 +41,20 @@
           chdir: "{{ web_app_frontend_path }}"
 
       - name: Run frontend build for pouta test environments
+        shell: npm run build -- --define process.env.NODE_ENV="'test'"
+        become_user: "{{ app_user }}"
+        args:
+          executable: /bin/bash
+          chdir: "{{ web_app_frontend_path }}"
+        when: deployment_environment_id in ['test', 'stable', 'demo']
+
+      - name: Run frontend build for production-like pouta environments
         shell: npm run build
         become_user: "{{ app_user }}"
         args:
           executable: /bin/bash
           chdir: "{{ web_app_frontend_path }}"
-        when: deployment_environment_id in ['test', 'stable', 'demo', 'staging']
+        when: deployment_environment_id == 'staging'
 
       - name: Run frontend build for production environment
         shell: npm run build -- --define process.env.MATOMO="'true'"


### PR DESCRIPTION
- Reverts CSCfi/etsin-ops#34
- This is done because 'production' gets chosen as a NODE_ENV in test and stable and thus prevents metax_api_v2 config from being enabled or disabled