### PR TITLE
Revert "CSCFAIRADM-407: Local support for running Etsin & Qvain Light with the old proxy auth"

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -11,8 +11,8 @@ redirect_ssl_certificate_name: redirect-nginx-selfsigned.crt
 redirect_ssl_certificate_key_name: redirect-nginx-selfsigned.key
 web_app_github_repo_branch: test
 search_app_github_repo_branch: test
-server_etsin_domain_name: 30.30.30.30
-server_qvain_domain_name: 30.30.30.30
+server_etsin_domain_name: etsin-finder.local
+server_qvain_domain_name: qvain.local
 redirect_server_etsin_domain_name: redirect.{{server_etsin_domain_name}}
 
 nginx_es_credentials:


### PR DESCRIPTION
Reverts CSCfi/etsin-ops#36
- This because setting the variables to having the same value causes Qvain to be used as default (and Etsin will never be used).
- Actually, login seems to work even while having the variables separate (etsin-finder.local & qvain.local)
- Thanks to @kasperkeinanen for notification about the issue and debugging