### PR TITLE
Shared proxy domain name for local dev to fix login

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -14,6 +14,7 @@ search_app_github_repo_branch: test
 server_etsin_domain_name: etsin-finder.local.fd-test.csc.fi
 server_qvain_domain_name: qvain.local.fd-test.csc.fi
 shared_domain_name: local.fd-test.csc.fi
+shared_domain_name_for_proxy: 30.30.30.30
 redirect_server_etsin_domain_name: redirect.{{server_etsin_domain_name}}
 
 nginx_es_credentials:

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -9,6 +9,7 @@ SEARCH_APP_LOG_PATH: {{ search_app_log_base_path }}/{{ search_app_project_name }
 # Variables related to etsin_finder app config
 SERVER_ETSIN_DOMAIN_NAME: {{ server_etsin_domain_name }}
 SERVER_QVAIN_DOMAIN_NAME: {{ server_qvain_domain_name }}
+SHARED_DOMAIN_NAME_FOR_PROXY: {{ shared_domain_name_for_proxy }}
 DEBUG: {{ app_debug_mode }}
 SECRET_KEY: {{ app_secret_key }}
 SESSION_COOKIE_SAMESITE: None

--- a/ansible/update_appconfig.yml
+++ b/ansible/update_appconfig.yml
@@ -18,7 +18,7 @@
 - hosts: dataservers
   become: yes
   tasks:
-    - name: Restart rabbimq-consumer
+    - name: Restart rabbitmq-consumer
       service:
         name: rabbitmq-consumer
         state: restarted


### PR DESCRIPTION
- This PR will provide support for adding a separate domain name value for the proxy
- This needs to be added, since the proxy is hard-coded to receive a certain value (30.30.30.30)
- This value will be added for all environments, but needs to be distinct only in local_dev