### PR TITLE
CSCFAIRMETA-770: Add language cookie domain app_config

### DIFF
--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -86,3 +86,4 @@ FD_REMS:
 
 # Variables related to Fairdata SSO
 SSO_PREFIX: {{ sso_prefix }}
+SSO_COOKIE_DOMAIN: {{ sso_cookie_domain | default('') }}


### PR DESCRIPTION
Adds new inventory variable sso_cookie_domain that should match the used sso_prefix, e.g.
```
sso_prefix: fd_test_csc_fi
sso_cookie_domain: fd-test.csc.fi
```

Used by https://github.com/CSCfi/etsin-finder/pull/628