### PR TITLE
CSCFAIRMETA-801: Support separate internal and public download service urls

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -84,6 +84,8 @@ download_api_v2:
   port: 4431
   user: Null
   password: Null
+  public_host: 'ida.fd-test.csc.fi'
+  public_port: 4430
 
 memcached:
   host: localhost

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -72,6 +72,8 @@ DOWNLOAD_API_V2:
   PORT: {{ download_api_v2.port }}
   USER: {{ download_api_v2.user }}
   PASSWORD: {{ download_api_v2.password }}
+  PUBLIC_HOST: {{ download_api_v2.public_host }}
+  PUBLIC_PORT: {{ download_api_v2.public_port }}
 {% endif %}
 
 # Variables related to Memcached cache


### PR DESCRIPTION
This adds `public_host` and `public_port` values to the `metax_api_v2` configuration object.