### PR TITLE
CSCFAIRMETA-821: Refactor SSO & SAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ etsin_finder_search/
 ansible/*.retry
 
 ansible/inventories/local_development/group_vars/local_development
-ansible/inventories/local_development/group_vars/local_development_sso
-ansible/inventories/local_development/group_vars/local_development_saml
 ansible/inventories/test/group_vars/*
 !ansible/inventories/test/group_vars/all
 ansible/inventories/test/host_vars
@@ -39,5 +37,3 @@ __pycache__
 
 # Visual studio code stuff
 .vscode
-
-faircentos

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ etsin_finder_search/
 ansible/*.retry
 
 ansible/inventories/local_development/group_vars/local_development
+ansible/inventories/local_development/group_vars/local_development_sso
+ansible/inventories/local_development/group_vars/local_development_saml
 ansible/inventories/test/group_vars/*
 !ansible/inventories/test/group_vars/all
 ansible/inventories/test/host_vars

--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -5,8 +5,6 @@ webserver_1_internal_ip: 127.0.0.1
 dataserver_1_internal_ip: 127.0.0.1
 
 deployment_environment_id: local_development
-ssl_certificate_name: fd-test.csc.fi.crt.pem
-ssl_key_name: fd-test.csc.fi.key.pem
 web_app_github_repo_branch: test
 search_app_github_repo_branch: test
 server_etsin_domain_name: etsin-local.fd-test.csc.fi

--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -5,13 +5,13 @@ webserver_1_internal_ip: 127.0.0.1
 dataserver_1_internal_ip: 127.0.0.1
 
 deployment_environment_id: local_development
-ssl_certificate_name: nginx-selfsigned.crt
-ssl_key_name: nginx-selfsigned.key
+ssl_certificate_name: fd-test.csc.fi.crt.pem
+ssl_key_name: fd-test.csc.fi.key.pem
 web_app_github_repo_branch: test
 search_app_github_repo_branch: test
-server_etsin_domain_name: etsin-finder.local.fd-test.csc.fi
-server_qvain_domain_name: qvain.local.fd-test.csc.fi
-shared_domain_name: local.fd-test.csc.fi
+server_etsin_domain_name: etsin-local.fd-test.csc.fi
+server_qvain_domain_name: qvain-local.fd-test.csc.fi
+shared_domain_name: fd-test.csc.fi
 shared_domain_name_for_proxy: 30.30.30.30
 
 nginx_es_credentials:

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -9,7 +9,6 @@ SEARCH_APP_LOG_PATH: {{ search_app_log_base_path }}/{{ search_app_project_name }
 # Variables related to etsin_finder app config
 SERVER_ETSIN_DOMAIN_NAME: {{ server_etsin_domain_name }}
 SERVER_QVAIN_DOMAIN_NAME: {{ server_qvain_domain_name }}
-SHARED_DOMAIN_NAME: {{ shared_domain_name }}
 SHARED_DOMAIN_NAME_FOR_PROXY: {{ shared_domain_name_for_proxy }}
 DEBUG: {{ app_debug_mode }}
 SECRET_KEY: {{ app_secret_key }}
@@ -17,6 +16,7 @@ SESSION_COOKIE_SAMESITE: None
 SESSION_COOKIE_SECURE: True
 SESSION_COOKIE_HTTPONLY: True
 SESSION_COOKIE_NAME: "etsin_session"
+SESSION_COOKIE_DOMAIN: {{ shared_domain_name }}
 PERMANENT_SESSION_LIFETIME: 1800
 SESSION_REFRESH_EACH_REQUEST: True
 

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -91,7 +91,7 @@ FD_REMS:
 SSO_PREFIX: {{ sso_prefix }}
 SSO_COOKIE_DOMAIN: {{ sso_cookie_domain | default('') }}
 SSO_KEY: {{ sso.sso_key }}
-SSO_AUTHORIZATION: {{ sso_authorization }}
+SSO_AUTHORIZATION: {{ sso_authorization | default(false) }}
 SSO_LOGIN_ETSIN: {{ sso.login.etsin }}
 SSO_LOGIN_QVAIN: {{ sso.login.qvain }}
 SSO_LOGOUT_ETSIN: {{ sso.logout.etsin }}

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -90,10 +90,8 @@ FD_REMS:
 # Variables related to Fairdata SSO
 SSO_COOKIE_DOMAIN: {{ sso_cookie_domain | default('') }}
 
-# Variables related to Fairdata SSO
 SSO:
   ENABLED: {{ sso.enabled | default(false) }}
   PREFIX: {{ sso.prefix }}
   KEY: {{ sso.key }}
-  COOKIE_DOMAIN: {{ sso.cookie_domain | default('') }}
   HOST: {{ sso.host }}

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -88,11 +88,9 @@ FD_REMS:
   API_KEY: {{ fd_rems.api_key | default('changeme') }}
 
 # Variables related to Fairdata SSO
-SSO_PREFIX: {{ sso_prefix }}
-SSO_COOKIE_DOMAIN: {{ sso_cookie_domain | default('') }}
-SSO_KEY: {{ sso.sso_key }}
-SSO_AUTHORIZATION: {{ sso_authorization | default(false) }}
-SSO_LOGIN_ETSIN: {{ sso.login.etsin }}
-SSO_LOGIN_QVAIN: {{ sso.login.qvain }}
-SSO_LOGOUT_ETSIN: {{ sso.logout.etsin }}
-SSO_LOGOUT_QVAIN: {{ sso.logout.qvain }}
+SSO:
+  ENABLED: {{ sso.enabled | default(false) }}
+  PREFIX: {{ sso.prefix }}
+  KEY: {{ sso.key }}
+  COOKIE_DOMAIN: {{ sso.cookie_domain | default('') }}
+  HOST: {{ sso.host }}

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -91,3 +91,8 @@ FD_REMS:
 SSO_PREFIX: {{ sso_prefix }}
 SSO_COOKIE_DOMAIN: {{ sso_cookie_domain | default('') }}
 SSO_KEY: {{ sso.sso_key }}
+SSO_AUTHORIZATION: {{ sso_authorization }}
+SSO_LOGIN_ETSIN: {{ sso.login.etsin }}
+SSO_LOGIN_QVAIN: {{ sso.login.qvain }}
+SSO_LOGOUT_ETSIN: {{ sso.logout.etsin }}
+SSO_LOGOUT_QVAIN: {{ sso.logout.qvain }}

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -9,6 +9,7 @@ SEARCH_APP_LOG_PATH: {{ search_app_log_base_path }}/{{ search_app_project_name }
 # Variables related to etsin_finder app config
 SERVER_ETSIN_DOMAIN_NAME: {{ server_etsin_domain_name }}
 SERVER_QVAIN_DOMAIN_NAME: {{ server_qvain_domain_name }}
+SHARED_DOMAIN_NAME: {{ shared_domain_name }}
 SHARED_DOMAIN_NAME_FOR_PROXY: {{ shared_domain_name_for_proxy }}
 DEBUG: {{ app_debug_mode }}
 SECRET_KEY: {{ app_secret_key }}
@@ -16,7 +17,6 @@ SESSION_COOKIE_SAMESITE: None
 SESSION_COOKIE_SECURE: True
 SESSION_COOKIE_HTTPONLY: True
 SESSION_COOKIE_NAME: "etsin_session"
-SESSION_COOKIE_DOMAIN: {{ shared_domain_name }}
 PERMANENT_SESSION_LIFETIME: 1800
 SESSION_REFRESH_EACH_REQUEST: True
 

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -88,6 +88,9 @@ FD_REMS:
   API_KEY: {{ fd_rems.api_key | default('changeme') }}
 
 # Variables related to Fairdata SSO
+SSO_COOKIE_DOMAIN: {{ sso_cookie_domain | default('') }}
+
+# Variables related to Fairdata SSO
 SSO:
   ENABLED: {{ sso.enabled | default(false) }}
   PREFIX: {{ sso.prefix }}

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -90,3 +90,4 @@ FD_REMS:
 # Variables related to Fairdata SSO
 SSO_PREFIX: {{ sso_prefix }}
 SSO_COOKIE_DOMAIN: {{ sso_cookie_domain | default('') }}
+SSO_KEY: {{ sso.sso_key }}

--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -33,7 +33,7 @@
         openssl:
         self_signed_cert:
         certs:
-  when: deployment_environment_id not in ['production', 'test', 'stable', 'demo']
+  when: deployment_environment_id not in ['production', 'test', 'stable', 'demo', 'local_development']
 
 - block:
     - name: Copy CA-signed primary certificate and private key
@@ -42,4 +42,4 @@
         - "{{ ssl_certificate_name }}"
         - "{{ ssl_key_name }}"
 
-  when: deployment_environment_id in ['test', 'stable', 'demo']
+  when: deployment_environment_id in ['test', 'stable', 'demo', 'local_development']


### PR DESCRIPTION
- Enable both SSO or SAML login, depending on app_config
- Enable/disable using the variable SSO_AUTHORIZATION (true/false)
- SSO calls moved to app_config (`ansible/roles/app_config/templates/app_config`)
- Refactor local URLs for SSO compatibility: `etsin-local.fd-test.csc.fi` & `qvain-local.fd-test.csc.fi`
- Take test certificates into use for local development for usage with SSO, move definition out of `../local_development/group_vars/all`