### PR TITLE
CSCFAIRMETA-834: Feature flags

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -77,7 +77,6 @@ download_api:
   password: changeme
 
 download_api_v2:
-  enabled: False
   host: 'ida.fd-test.csc.fi'
   port: 4431
   user: Null
@@ -110,3 +109,9 @@ fd_rems:
 matomo:
   host: matomo.csc.local
   port: 80
+
+flags:
+  DOWNLOAD_API_V2.BACKEND: true
+  DOWNLOAD_API_V2.FRONTEND: false
+  METAX_API_V2.BACKEND: true
+  METAX_API_V2.FRONTEND: false

--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -95,3 +95,9 @@ SSO:
   PREFIX: {{ sso.prefix }}
   KEY: {{ sso.key }}
   HOST: {{ sso.host }}
+
+{% if flags | default(false) %}
+# Runtime feature flags
+FLAGS:
+  {{ flags | to_nice_yaml | indent(2) }}
+{% endif %}


### PR DESCRIPTION
* Add new "flags" inventory variable
* Add FLAGS dict to app_config
* Use flags.DOWNLOAD_API_V2 instead of DOWNLOAD_API_V2.ENABLED
* Enable backend support for Download API v2 and Metax API v2 in local development