### PR TITLE
CSCFAIRMETA-913: Remove SSO_COOKIE_DOMAIN

### DIFF
--- a/ansible/roles/app_config/templates/app_config
+++ b/ansible/roles/app_config/templates/app_config
@@ -88,8 +88,6 @@ FD_REMS:
   API_KEY: {{ fd_rems.api_key | default('changeme') }}
 
 # Variables related to Fairdata SSO
-SSO_COOKIE_DOMAIN: {{ sso_cookie_domain | default('') }}
-
 SSO:
   ENABLED: {{ sso.enabled | default(false) }}
   PREFIX: {{ sso.prefix }}


### PR DESCRIPTION
Etsin will now default to SESSION_COOKIE_DOMAIN (e.g. fd-test.csc.fi) for the SSO language cookie domain value, so the value no longer needs to be explicitly set unless it would be different.

Related to https://github.com/CSCfi/etsin-finder/pull/699

