### PR TITLE
CSCFAIRADM-415: Remove support for TLS 1.1

### DIFF
--- a/ansible/roles/nginx/templates/shared_ssl_configurations.conf
+++ b/ansible/roles/nginx/templates/shared_ssl_configurations.conf
@@ -1,4 +1,4 @@
-ssl_protocols TLSv1.1 TLSv1.2;
+ssl_protocols TLSv1.2;
 ssl_prefer_server_ciphers on;
 ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
 ssl_ecdh_curve secp384r1;


### PR DESCRIPTION
- This will improve the sslabs security rating (https://www.ssllabs.com/ssltest/) to A+