### PR TITLE
CSCFAIRMETA-979: Upgrade pip

### DIFF
--- a/ansible/roles/deploy_webservers/tasks/main.yml
+++ b/ansible/roles/deploy_webservers/tasks/main.yml
@@ -64,6 +64,10 @@
 
     when: deployment_environment_id in ['staging', 'production']
 
+  - name: Install latest pip version
+    pip: name=pip state=latest virtualenv={{ python_virtualenv_path }}
+    become_user: "{{ app_user }}"
+
   - name: Install web app python package requirements
     pip: requirements={{ web_app_base_path }}/requirements.txt virtualenv={{ python_virtualenv_path }}
     become_user: "{{ app_user }}"

--- a/ansible/roles/provision_web_app/tasks/main.yml
+++ b/ansible/roles/provision_web_app/tasks/main.yml
@@ -15,6 +15,10 @@
     become_user: "{{ app_user }}"
     ignore_errors: yes
 
+  - name: Install latest pip version
+    pip: name=pip state=latest virtualenv={{ python_virtualenv_path }}
+    become_user: "{{ app_user }}"
+
   - name: Install web app python package requirements
     pip: requirements={{ web_app_base_path }}/requirements.txt virtualenv={{ python_virtualenv_path }}
     become_user: "{{ app_user }}"


### PR DESCRIPTION
The download notification PR https://github.com/CSCfi/etsin-finder/pull/793 uses `cryptography` library which needs a newer version of `pip` to install properly. This PR upgrades pip before installing requirements.txt.