### PR TITLE
CSCFAIRMETA-1007: Remove Content-Disposition headers

### DIFF
--- a/ansible/roles/nginx/templates/api_response_headers.conf
+++ b/ansible/roles/nginx/templates/api_response_headers.conf
@@ -1,3 +1,3 @@
 add_header Cache-Control "no-store" always;
 add_header Content-Security-Policy "default-src 'self'";
-add_header Content-Disposition 'attachment; filename=response.json' always;
+

--- a/ansible/roles/nginx/templates/elastic_headers.conf
+++ b/ansible/roles/nginx/templates/elastic_headers.conf
@@ -1,4 +1,3 @@
 # note: elastic has additional headers, such as cors-related, in elastic search config!
 add_header Cache-Control "public" always;
 add_header Content-Security-Policy "default-src 'self'";
-add_header Content-Disposition 'attachment; filename=response.json' always;

--- a/ansible/roles/nginx/templates/server_common.conf
+++ b/ansible/roles/nginx/templates/server_common.conf
@@ -62,15 +62,8 @@ location /build/ {
 }
 
 location /api/dl {
-    # separate block for dl api to not include content-disposition header
     include shared_headers.conf;
-    add_header Cache-Control "no-store" always;
-    add_header Content-Security-Policy "default-src 'self'";
-
-    proxy_pass {{ nginx_gunicorn_proxy_pass }};
-    proxy_set_header X-Forwarded-Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    include api_response_headers.conf;
     proxy_max_temp_file_size 0;
 }
 


### PR DESCRIPTION
Removing the Content-Disposition headers fixes some issues with Chrome and makes debugging easier.

Required by https://github.com/CSCfi/etsin-finder/pull/801